### PR TITLE
fix echo to keep the qdrouter.conf format (EOS) instead of inlining it

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -171,7 +171,11 @@ EOS
     fi
 
     if [ "$QDROUTERD_CONFIG_OPTIONS" ]; then
-        echo $QDROUTERD_CONFIG_OPTIONS > $QDROUTERD_CONFIG_FILE
+        #echo $QDROUTERD_CONFIG_OPTIONS > $QDROUTERD_CONFIG_FILE
+	cat >> $QDROUTERD_CONFIG_FILE <<-EOS
+$QDROUTERD_CONFIG_OPTIONS
+EOS
+	have_config=1
     else
         if [ ! -f "$QDROUTERD_CONFIG_FILE" ]; then
             have_config=1
@@ -182,7 +186,7 @@ router {
     id: $QDROUTERD_ID
     workerThreads: $QDROUTERD_WORKER_THREADS
 EOS
-
+	
             if [ $have_sasl -eq "1" ]; then
                 cat >> $QDROUTERD_CONFIG_FILE <<-EOS
     saslConfigPath: $QDROUTERD_SASL_CONFIG_DIR

--- a/tests.bats
+++ b/tests.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 
-IMAGE="qpid-dispatch"
-VERSION="0.6.1"
+IMAGE="scholzj/qpid-dispatch"
+VERSION="travis"
 
 IFSBAK=$IFS
 IFS=""

--- a/tests/qdrouterd-options.conf
+++ b/tests/qdrouterd-options.conf
@@ -1,0 +1,32 @@
+router {
+  mode: standalone
+  id: ZTZiNmVlZTM2ZjljZDA2N2MwY2I2NWI3
+  workerThreads: 4
+} 
+listener {
+  role: normal
+  host: 0.0.0.0
+  port: 5672
+  linkCapacity: 1000
+}
+log {
+  module: DEFAULT
+  enable: trace+
+  timestamp: true
+}
+autoLink {
+    addr: myOtherTestAddress
+    dir: in
+    connection: myTestConnector
+}
+
+connector {
+    host: 127.0.0.1
+    name: myTestConnector
+    port: 12345
+    role: normal
+    saslMechanisms: PLAIN
+    allowRedirect: no
+    saslUsername: admin
+    saslPassword: admin
+}


### PR DESCRIPTION
The echo was not working on my side (ubuntu) 

the initial config file 

```
router {
....
}
policy....
```

was "inlining" like 
`router {....} policy {...`

resulting in a failure while starting qdrouterd in the container. 

Do not know if you had the same issue but in case. Hope this helps. 
